### PR TITLE
bleve-blast more concurrency between wiki reader and indexers

### DIFF
--- a/cmd/bleve-blast/main.go
+++ b/cmd/bleve-blast/main.go
@@ -32,6 +32,7 @@ var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
 var memprofile = flag.String("memprofile", "", "write memory profile at end")
 var numIndexers = flag.Int("numIndexers", 8, "number of indexing goroutines")
 var numAnalyzers = flag.Int("numAnalyzers", 8, "number of analyzer goroutines")
+var readerQueueSize = flag.Int("readerQueueSize", 8, "size of queue output from reader")
 var printTime = flag.Duration("printTime", 5*time.Second, "print stats every printTime")
 var bindHttp = flag.String("bindHttp", ":1234", "http bind port")
 var statsFile = flag.String("statsFile", "", "<stdout>")
@@ -91,7 +92,7 @@ func main() {
 	timeLast = timeStart
 	printLine()
 
-	work := make(chan *Work)
+	work := make(chan *Work, *readerQueueSize)
 
 	// start reading worker
 	go readingWorker(index, work)


### PR DESCRIPTION
Doing this as a pull-request as it "changes the experiment" of bleve-blast.

The hope is that by the time an indexer is ready to handle more work, this change increases the likelihood that reader input work is al queued up and ready, instead of possibly waiting for more input file reading and parsing.

An alternative idea that popped to mind (but not part of this PR) to "just measuring indexing" perf... would be to have input reading+parsing done synchronously, so there would be clear, accountable phases of input reading time versus indexing time.  With a clear separation of phases, we'd then only count the indexing time and throughput.