### PR TITLE
index.Close() at end of bleve-blast

### DIFF
--- a/cmd/bleve-blast/main.go
+++ b/cmd/bleve-blast/main.go
@@ -118,6 +118,8 @@ func main() {
 
 	// print final stats
 	printLine()
+
+	index.Close()
 }
 
 type Work struct {


### PR DESCRIPTION
This PR is related to the https://github.com/blevesearch/blevex/pull/14 workaround for writeoptions destroy during index.Close()...

When I added this index.Close() to bleve-blast, I get a reproduction of the writeoptions destroy crash that was reported in https://github.com/blevesearch/bleve/issues/332.  So, bleve-blast is usable as a test case

Then, when I apply the leaky workaround PR to rocksdb blevex, where the writeoptions Destory() is commented out in https://github.com/blevesearch/blevex/pull/14, then bleve-blast no longer crashes.