### PR TITLE
add support for generating execution trace profiles

### DIFF
--- a/cmd/bleve-analyzer/main.go
+++ b/cmd/bleve-analyzer/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"runtime/pprof"
+	"runtime/trace"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,6 +37,7 @@ var printTime = flag.Duration("printTime", 5*time.Second, "print stats every pri
 var bindHTTP = flag.String("bindHttp", ":1234", "http bind port")
 var count = flag.Int("count", 100000, "total number of documents to process")
 var statsFile = flag.String("statsFile", "", "<stdout>")
+var traceprofile = flag.String("traceprofile", "", "write trace profile to file")
 
 var tokensProduced uint64
 var lastTokensProduced uint64
@@ -70,6 +72,16 @@ func main() {
 		defer f.Close()
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
+	}
+
+	if *traceprofile != "" {
+		f, err := os.Create(*traceprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		trace.Start(f)
+		defer trace.Stop()
 	}
 
 	defineCustomAnalyzers()

--- a/cmd/bleve-blast/main.go
+++ b/cmd/bleve-blast/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"runtime/pprof"
+	"runtime/trace"
 	"strconv"
 	"strings"
 	"sync"
@@ -41,6 +42,7 @@ var printTime = flag.Duration("printTime", 5*time.Second, "print stats every pri
 var bindHttp = flag.String("bindHttp", ":1234", "http bind port")
 var statsFile = flag.String("statsFile", "", "<stdout>")
 var waitPersist = flag.Bool("waitPersist", false, "wait for all data to be persisted before closing")
+var traceprofile = flag.String("traceprofile", "", "write trace profile to file")
 
 var totalIndexed uint64
 var lastTotalIndexed uint64
@@ -77,6 +79,16 @@ func main() {
 		defer f.Close()
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
+	}
+
+	if *traceprofile != "" {
+		f, err := os.Create(*traceprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		trace.Start(f)
+		defer trace.Stop()
 	}
 
 	bleve.Config.SetAnalysisQueueSize(*numAnalyzers)

--- a/cmd/bleve-query/main.go
+++ b/cmd/bleve-query/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"runtime/pprof"
+	"runtime/trace"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,7 @@ var qfield = flag.String("field", "text", "the field to query, not applicable to
 var qclients = flag.Int("clients", 1, "the number of query clients")
 var qtime = flag.Duration("time", 1*time.Minute, "time to run the test")
 var printTime = flag.Duration("printTime", 5*time.Second, "print stats every printTime")
+var traceprofile = flag.String("traceprofile", "", "write trace profile to file")
 
 var statsWriter = os.Stdout
 
@@ -63,6 +65,16 @@ func main() {
 		defer f.Close()
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
+	}
+
+	if *traceprofile != "" {
+		f, err := os.Create(*traceprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		trace.Start(f)
+		defer trace.Stop()
 	}
 
 	if flag.NArg() < 1 {


### PR DESCRIPTION
Here is an example invocation of bleve-query which generates the trace profile:

```
$ go build ./cmd/bleve-query/ && rm trace.pprof && ./bleve-query -traceprofile trace.pprof -clients 16 -index=test.bleve book can date first http isbn last many name one see title united web year
```

NOTE: this invocation creates 16 clients (concurrent queriers) so that the trace is more interesting, most of our measured benchmark focus on latency of single querier.

Then once you have the trace profile, you can handle it with:

```
go tool trace trace.pprof
```